### PR TITLE
Corrigindo bug de retorno das permissões do usuário

### DIFF
--- a/app/Controller/UserController.php
+++ b/app/Controller/UserController.php
@@ -47,10 +47,6 @@ final class UserController extends AbstractController
             'updated_at'
         )->get();
 
-        foreach ($user as $key => $value) {
-            $user[$key]['permissions'] = unserialize($value['permissions']);
-        }
-
         return $this->response->json($user);
     }
 

--- a/app/Controller/UserController.php
+++ b/app/Controller/UserController.php
@@ -34,7 +34,7 @@ final class UserController extends AbstractController
 
     public function index()
     {
-        return User::select(
+        $user = User::select(
             'uuid',
             'name',
             'cidade',
@@ -46,6 +46,12 @@ final class UserController extends AbstractController
             'created_at',
             'updated_at'
         )->get();
+
+        foreach ($user as $key => $value) {
+            $user[$key]['permissions'] = unserialize($value['permissions']);
+        }
+
+        return $this->response->json($user);
     }
 
     public function create(UserRegisterRequest $request)

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -1,23 +1,32 @@
 <?php
 
 declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
 
 namespace App\Model;
 
+use Carbon\Carbon;
 use Hyperf\DbConnection\Model\Model;
 
 /**
- * @property int $id 
- * @property string $uuid 
- * @property string $name 
- * @property string $email 
- * @property string $birth_date 
- * @property string $document 
- * @property string $cellphone 
- * @property string $password 
- * @property string $remember_token 
- * @property \Carbon\Carbon $created_at 
- * @property \Carbon\Carbon $updated_at 
+ * @property int $id
+ * @property string $uuid
+ * @property string $name
+ * @property string $email
+ * @property string $birth_date
+ * @property string $document
+ * @property string $cellphone
+ * @property string $password
+ * @property string $remember_token
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
  */
 class User extends Model
 {
@@ -34,10 +43,16 @@ class User extends Model
     protected array $guarded = [];
 
     protected array $hidden = ['password', 'email', 'id', 'remember_token'];
+
     /**
      * The attributes that should be cast to native types.
      */
     protected array $casts = ['id' => 'integer', 'created_at' => 'datetime', 'updated_at' => 'datetime'];
 
     /* protected ?string $connection = 'default'; */
+
+    public function getPermissionsAttribute($value)
+    {
+        return unserialize($value);
+    }
 }


### PR DESCRIPTION
Ao retornar o usuário, as permissões estavam indo como resposta em forma de texto no padrão normalize do php, alterei para que sejam retornadas em forma de objeto.